### PR TITLE
feat: add option to restrict search to some directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ To avoid taking into account the `.gitignore`, we need to pass `--no-ignore-vcs`
 
 This will list `M` and `S` in the Telescope output! The downside is that listing repositories will be a little longer, as we don’t skip the git-ignored files anymore.
 
+##### `search_dirs`
+
+This limits the search to a particular directory or set of directories.
+
+##### Example
+```
+:lua require'telescope'.extensions.repo.list{search_dirs = {"~/ghq/github.com", "~/ghq/git.sr.ht"}}
+:lua require'telescope'.extensions.repo.list{search_dirs = {"~/.local/share/nvim/site/pack"}}
+```
+
 ##### `tail_path`
 
 Show only basename of the path.
@@ -233,9 +243,10 @@ if you encounter any problems. If it’s not the case by default, you should aut
 
 #### Options
 
-Options are the similar to `repo list`, bearing in mind that we use `locate` instead of `fd`. Note that:
+Options are the similar to `repo list`, bearing in mind that we use `locate` instead of `fd`. Note that the following `list` options are not supported in `cached_list`:
 
-* `fd_opts` is not supported, as we don’t use `fd`
+* `fd_opts`, as we don’t use `fd` with `cached_list`,
+* `search_dirs`, as `locate` does not accept a directory to search in.
 
 #### Examples
 

--- a/lua/telescope/_extensions/repo/list.lua
+++ b/lua/telescope/_extensions/repo/list.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local log = require("telescope.log")
 local utils = require("telescope._extensions.repo.utils")
 
 -- Prepare fd command and change opts accordingly
@@ -32,7 +33,7 @@ M.prepare_command = function(opts)
     table.insert(fd_command, repo_pattern)
     table.insert(fd_command, search_dirs)
     fd_command = vim.tbl_flatten(fd_command)
-    print(vim.inspect(fd_command))
+    log.trace("fd command: " .. vim.inspect(fd_command))
 
     return fd_command
 end

--- a/lua/telescope/_extensions/repo/list.lua
+++ b/lua/telescope/_extensions/repo/list.lua
@@ -19,13 +19,20 @@ M.prepare_command = function(opts)
     local find_repo_opts = { "--hidden", "--case-sensitive", "--absolute-path" }
     local find_user_opts = opts.fd_opts or {}
     local find_exec_opts = { "--exec", "echo", [[{//}]], ";" }
-    local find_pattern_opts = { repo_pattern }
+
+    -- Expand '~'
+    local search_dirs = {}
+    for i, d in ipairs(opts.search_dirs) do
+        search_dirs[i] = vim.fn.expand(d)
+    end
 
     table.insert(fd_command, find_repo_opts)
     table.insert(fd_command, find_user_opts)
     table.insert(fd_command, find_exec_opts)
-    table.insert(fd_command, find_pattern_opts)
+    table.insert(fd_command, repo_pattern)
+    table.insert(fd_command, search_dirs)
     fd_command = vim.tbl_flatten(fd_command)
+    print(vim.inspect(fd_command))
 
     return fd_command
 end


### PR DESCRIPTION
Implement the option requested in #24. With `list`, we can now search in
a specific directory and get more accurate results more quickly.

*Note*: unfortunately, this does not seem to work in a performant manner
with `cached_list`, as `locate` does not seem to accept a directory to
search in. The filtering would need to be done in Lua, and that can be
slow.
