### PR TITLE
fix: pass down the opts to the second prompts

### DIFF
--- a/lua/telescope/_extensions/repo/main.lua
+++ b/lua/telescope/_extensions/repo/main.lua
@@ -164,20 +164,20 @@ local function call_picker(opts, command, prompt_title_supplement)
                 if type == "default" then
                     actions._close(prompt_bufnr, false)
                     vim.schedule(function()
-                        project_files({ cwd = dir })
+                        project_files(vim.tbl_extend("force", opts, { cwd = dir }))
                     end)
                 end
                 if type == "vertical" then
                     actions._close(prompt_bufnr, false)
                     vim.schedule(function()
-                        project_live_grep({ cwd = dir })
+                        project_live_grep(vim.tbl_extend("force", opts, { cwd = dir }))
                     end)
                     return
                 end
                 if type == "tab" then
                     vim.cmd("tabe " .. dir)
                     vim.cmd("tcd " .. dir)
-                    project_files({ cwd = dir })
+                    project_files(vim.tbl_extend("force", opts, { cwd = dir }))
                     return
                 end
             end)


### PR DESCRIPTION
Before this patch, the “global” options passed to the Telescope command
were not passed down to the second prompt (the one selecting the files
for instance). This would cause a change of layout set like so:

```
:Telescope repo list layout_strategy=center
```

not to be applied to the second prompt.

This patch fixes that and correctly passes the options down to the
second prompt.

Related to #44 (might fix it)
