### PR TITLE
Detect batcat too

### DIFF
--- a/lua/telescope/_extensions/repo/utils.lua
+++ b/lua/telescope/_extensions/repo/utils.lua
@@ -22,7 +22,7 @@ M.find_locate_binary = function()
     return find_binary({ "plocate", "lolcate", "glocate", "locate" })
 end
 
-M._generic_previewer = { { "bat", "--style", "header,grid" }, { "cat" } }
+M._generic_previewer = { { "bat", "--style", "header,grid" }, { "batcat", "--style", "header,grid" }, { "cat" } }
 
 M.find_generic_previewer_for_document = function(doc)
     local l = find_binary(M._generic_previewer)


### PR DESCRIPTION
Some debian-based systems use put `bat` under `/usr/bin/batcat`. We thus
need a to look for `batcat` as well.

Fixes #47

[1]: https://packages.debian.org/bullseye/amd64/bat/filelist, https://web.archive.org/web/20221016131458/https://packages.debian.org/bullseye/amd64/bat/filelist


