### PR TITLE
Makefile improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root                     = true
+
+[*]
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+charset                  = utf-8
+
+[*.lua]
+indent_style             = space
+indent_size              = 4
+
+[Makefile]
+indent_style             = tab

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ fmt:
 
 lint:
 	@luacheck lua/telescope
+
+tags:
+	@ctags -R . ~/.local/share/nvim/site/pack/*/*/*/lua/

--- a/lua/telescope/_extensions/repo/cached_list.lua
+++ b/lua/telescope/_extensions/repo/cached_list.lua
@@ -7,7 +7,7 @@ local utils = require("telescope._extensions.repo.utils")
 M.prepare_command = function(opts)
     opts = opts or {}
     opts.bin = opts.bin or utils.find_locate_binary()
-    if opts.bin == "" then
+    if not opts.bin then
         error("Please install locate (or one of its alternatives)")
     end
     opts.cwd = vim.env.HOME

--- a/lua/telescope/_extensions/repo/health.lua
+++ b/lua/telescope/_extensions/repo/health.lua
@@ -79,33 +79,38 @@ local function check_cached_list_cmd()
     end
 end
 
-local function check_previewer()
+local function check_previewer_md()
     local markdown_bin = utils.find_markdown_previewer_for_document("test_doc.md")
     if not markdown_bin then
         health.report_error("No markdown previewer found, the extension will not work properly")
-    else
-        health.report_ok("Will use `" .. markdown_bin[1] .. "` to preview markdown READMEs")
-
-        if markdown_bin[1] ~= utils._markdown_previewer[1][1] then
-            health.report_warn("Install `" .. utils._markdown_previewer[1][1] .. "` for a better preview of markdown files")
-        end
+        return
     end
+    health.report_ok("Will use `" .. markdown_bin[1] .. "` to preview markdown READMEs")
 
+    local first = utils._markdown_previewer[1][1]
+    if markdown_bin[1] ~= first then
+        health.report_warn("Install `" .. first .. "` for a better preview of markdown files")
+    end
+end
+
+local function check_previewer_generic()
     local generic_bin = utils.find_generic_previewer_for_document("test_doc")
     if not generic_bin then
         health.report_error("No markdown previewer found, the extension will not work properly")
-    else
-        health.report_ok("Will use `" .. generic_bin[1] .. "` to preview non-markdown READMEs")
+        return
+    end
+    health.report_ok("Will use `" .. generic_bin[1] .. "` to preview non-markdown READMEs")
 
-        if generic_bin[1] ~= utils._generic_previewer[1][1] then
-            health.report_warn("Install `" .. utils._generic_previewer[1][1] .. "` for a better preview of other files")
-        end
+    local first = utils._generic_previewer[1][1]
+    if generic_bin[1] ~= first then
+        health.report_warn("Install `" .. first .. "` for a better preview of other files")
     end
 end
 
 M.check = function()
     -- Ordered from fastest to slowest
-    check_previewer()
+    check_previewer_generic()
+    check_previewer_md()
     check_cached_list_cmd()
     check_list_cmd()
 end

--- a/lua/telescope/_extensions/repo/health.lua
+++ b/lua/telescope/_extensions/repo/health.lua
@@ -46,7 +46,7 @@ end
 
 local function check_list_cmd()
     local fd_bin = utils.find_fd_binary()
-    if fd_bin ~= "" then
+    if fd_bin then
         health.report_ok("fd: found `" .. fd_bin .. "`\n" .. get_version(fd_bin))
 
         local opts = {}
@@ -59,7 +59,7 @@ end
 
 local function check_cached_list_cmd()
     local locate_bin = utils.find_locate_binary()
-    if locate_bin ~= "" then
+    if locate_bin then
         health.report_ok("locate: found `" .. locate_bin .. "`\n" .. get_version(locate_bin))
 
         local opts = {}
@@ -81,16 +81,26 @@ end
 
 local function check_previewer()
     local markdown_bin = utils.find_markdown_previewer_for_document("test_doc.md")
-    if markdown_bin[1] ~= utils._markdown_previewer[1][1] then
-        health.report_warn("Install `" .. utils._markdown_previewer[1][1] .. "` for a better preview of markdown files")
+    if not markdown_bin then
+        health.report_error("No markdown previewer found, the extension will not work properly")
+    else
+        health.report_ok("Will use `" .. markdown_bin[1] .. "` to preview markdown READMEs")
+
+        if markdown_bin[1] ~= utils._markdown_previewer[1][1] then
+            health.report_warn("Install `" .. utils._markdown_previewer[1][1] .. "` for a better preview of markdown files")
+        end
     end
-    health.report_ok("Will use `" .. markdown_bin[1] .. "` to preview markdown READMEs")
 
     local generic_bin = utils.find_generic_previewer_for_document("test_doc")
-    if generic_bin[1] ~= utils._generic_previewer[1][1] then
-        health.report_warn("Install `" .. utils._generic_previewer[1][1] .. "` for a better preview of other files")
+    if not generic_bin then
+        health.report_error("No markdown previewer found, the extension will not work properly")
+    else
+        health.report_ok("Will use `" .. generic_bin[1] .. "` to preview non-markdown READMEs")
+
+        if generic_bin[1] ~= utils._generic_previewer[1][1] then
+            health.report_warn("Install `" .. utils._generic_previewer[1][1] .. "` for a better preview of other files")
+        end
     end
-    health.report_ok("Will use `" .. generic_bin[1] .. "` to preview non-markdown READMEs")
 end
 
 M.check = function()

--- a/lua/telescope/_extensions/repo/list.lua
+++ b/lua/telescope/_extensions/repo/list.lua
@@ -7,7 +7,7 @@ local utils = require("telescope._extensions.repo.utils")
 M.prepare_command = function(opts)
     opts = opts or {}
     opts.bin = opts.bin or utils.find_fd_binary()
-    if opts.bin == "" then
+    if not opts.bin then
         error("fd not found, is fd installed?")
     end
     opts.cwd = vim.env.HOME

--- a/lua/telescope/_extensions/repo/utils.lua
+++ b/lua/telescope/_extensions/repo/utils.lua
@@ -22,7 +22,7 @@ M.find_locate_binary = function()
     return find_binary({ "plocate", "lolcate", "glocate", "locate" })
 end
 
-M._generic_previewer = { { "bat", "--style", "header,grid" }, { "cat" } }
+M._generic_previewer = { { "bat", "--style", "header,grid" }, { "batcat", "--style", "header,grid" }, { "cat" } }
 
 M.find_generic_previewer_for_document = function(doc)
     local l = find_binary(M._generic_previewer)

--- a/lua/telescope/_extensions/repo/utils.lua
+++ b/lua/telescope/_extensions/repo/utils.lua
@@ -9,7 +9,7 @@ local function find_binary(binaries)
             return vim.deepcopy(binary)
         end
     end
-    return ""
+    return nil
 end
 
 -- Find under what name fd is installed.
@@ -26,7 +26,9 @@ M._generic_previewer = { { "bat", "--style", "header,grid" }, { "cat" } }
 
 M.find_generic_previewer_for_document = function(doc)
     local l = find_binary(M._generic_previewer)
-    table.insert(l, doc)
+    if l then
+        table.insert(l, doc)
+    end
     return l
 end
 
@@ -35,7 +37,9 @@ vim.list_extend(M._markdown_previewer, M._generic_previewer)
 
 M.find_markdown_previewer_for_document = function(doc)
     local l = find_binary(M._markdown_previewer)
-    table.insert(l, doc)
+    if l then
+        table.insert(l, doc)
+    end
     return l
 end
 


### PR DESCRIPTION
chore: add a target to generate tags

This helps when a LSP is unavailable or does not find a particular
symbol.
