### PR TITLE
fix: allow cached opts.cwd to be reset if nil

### DIFF
--- a/lua/telescope/_extensions/repo/main.lua
+++ b/lua/telescope/_extensions/repo/main.lua
@@ -71,6 +71,7 @@ local function gen_from_fd(opts)
     -- display function
     local cwd = opts.cwd
     local function make_display(entry)
+        if not cwd then cwd = opts.cwd end
         local dir = (function(path)
             if path == Path.path.root() then
                 return path


### PR DESCRIPTION
#70 caused an issue for me where the `cwd` got stuck as `nil`, I haven't yet investigated further but it seems that the default value of `opts.cwd` is not set as early as we think it is. For now, this should fix the issue.