### PR TITLE
fix: allow cached opts.cwd to be reset if nil

### DIFF
--- a/lua/telescope/_extensions/repo/main.lua
+++ b/lua/telescope/_extensions/repo/main.lua
@@ -71,6 +71,11 @@ local function gen_from_fd(opts)
     -- display function
     local cwd = opts.cwd
     local function make_display(entry)
+        -- The value `opts.cwd` might have been nil when it was fixed. This
+        -- resets it if it was nil.
+        if not cwd then
+            cwd = opts.cwd
+        end
         local dir = (function(path)
             if path == Path.path.root() then
                 return path


### PR DESCRIPTION
Sometimes, when we cache opts.cwd, it is still nil. While this problem
is investigated [separately][1], it’s worth having this workaround, to
be on the safe side. It’s very disruptive when items can’t be diplayed.

[1]: https://github.com/cljoly/telescope-repo.nvim/pull/70#issuecomment-2014750473

Originally authored by @rish987 in #71. I’ve made cosmetic changes and
added some comments.

Co-authored-by: Rishikesh Vaishnav <rishhvaishnav@gmail.com>
